### PR TITLE
Fixed: load Ask AI styles from a fresh URL to bypass stale CDN cache

### DIFF
--- a/marketplace/developer-guide/mkdocs.yml
+++ b/marketplace/developer-guide/mkdocs.yml
@@ -58,6 +58,7 @@ extra_css:
     - assets/stylesheets/main.css
     - assets/stylesheets/fonts.css
     - assets/stylesheets/version-selector.css
+    - assets/stylesheets/ai-overrides.css
 
 extra_javascript:
     - assets/scripts/version-redirect.js

--- a/marketplace/user-guide/mkdocs.yml
+++ b/marketplace/user-guide/mkdocs.yml
@@ -58,6 +58,7 @@ extra_css:
     - assets/stylesheets/main.css
     - assets/stylesheets/fonts.css
     - assets/stylesheets/version-selector.css
+    - assets/stylesheets/ai-overrides.css
 
 extra_javascript:
     - assets/scripts/version-redirect.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -609,3 +609,4 @@ extra_css:
     - assets/stylesheets/main.css
     - assets/stylesheets/fonts.css
     - assets/stylesheets/version-selector.css
+    - assets/stylesheets/ai-overrides.css

--- a/overrides/assets/stylesheets/ai-overrides.css
+++ b/overrides/assets/stylesheets/ai-overrides.css
@@ -1,0 +1,84 @@
+/* Loaded as a separate extra_css entry. Its URL is fresh, so Cloudflare cannot
+   serve a stale copy that pre-dates the AI button. Keep all AI-button styles
+   and any selector overrides for cached neighbours of main.css here. */
+
+.md-search {
+    margin-right: 0.6rem;
+}
+
+@media screen and (max-width: 1265px) {
+    .md-search {
+        margin-right: 0.6rem;
+    }
+}
+
+.md-header__ai-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    height: 36px;
+    padding: 0 0.75rem;
+    margin-right: 0.6rem;
+    background-color: var(--search-bg-color);
+    color: var(--text-color);
+    border: 1px solid var(--search-border-color);
+    border-radius: 6px;
+    font-family: "CircularStd", sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    line-height: 1;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.md-header__ai-button:hover {
+    background-color: var(--neutral-95);
+    border-color: #FF7E13;
+    color: #FF7E13;
+}
+
+.md-header__ai-button:focus-visible {
+    outline: 2px solid #FF7E13;
+    outline-offset: 2px;
+}
+
+.md-header__ai-button-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #FF7E13;
+}
+
+.md-header__ai-button-icon svg {
+    width: 0.9rem;
+    height: 0.9rem;
+    fill: currentColor;
+    display: block;
+}
+
+.md-header__ai-button-label {
+    display: inline-block;
+}
+
+.md-header__ai-button--mobile {
+    display: none;
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    justify-content: center;
+}
+
+@media screen and (max-width: 1050px) {
+    .md-header__ai-button:not(.md-header__ai-button--mobile) {
+        display: none;
+    }
+
+    .md-header__ai-button--mobile {
+        display: inline-flex;
+    }
+}
+
+[data-md-toggle="search"]:checked ~ .md-header .md-header__ai-button {
+    display: none;
+}

--- a/platform/deployment-on-cloud/mkdocs.yml
+++ b/platform/deployment-on-cloud/mkdocs.yml
@@ -58,6 +58,7 @@ extra_css:
     - assets/stylesheets/main.css
     - assets/stylesheets/fonts.css
     - assets/stylesheets/version-selector.css
+    - assets/stylesheets/ai-overrides.css
 
 extra_javascript:
     - assets/scripts/version-redirect.js

--- a/platform/developer-guide/mkdocs.yml
+++ b/platform/developer-guide/mkdocs.yml
@@ -88,6 +88,7 @@ extra_css:
     - assets/stylesheets/main.css
     - assets/stylesheets/fonts.css
     - assets/stylesheets/version-selector.css
+    - assets/stylesheets/ai-overrides.css
 
 extra_javascript:
     - assets/scripts/version-redirect.js

--- a/platform/user-guide/mkdocs.yml
+++ b/platform/user-guide/mkdocs.yml
@@ -58,6 +58,7 @@ extra_css:
     - assets/stylesheets/main.css
     - assets/stylesheets/fonts.css
     - assets/stylesheets/version-selector.css
+    - assets/stylesheets/ai-overrides.css
 
 extra_javascript:
     - assets/scripts/version-redirect.js

--- a/storefront/developer-guide/mkdocs.yml
+++ b/storefront/developer-guide/mkdocs.yml
@@ -50,6 +50,7 @@ extra_css:
     - assets/stylesheets/main.css
     - assets/stylesheets/fonts.css
     - assets/stylesheets/version-selector.css
+    - assets/stylesheets/ai-overrides.css
 
 extra_javascript:
     - assets/scripts/version-redirect.js

--- a/storefront/user-guide/mkdocs.yml
+++ b/storefront/user-guide/mkdocs.yml
@@ -57,6 +57,7 @@ extra_css:
     - assets/stylesheets/main.css
     - assets/stylesheets/fonts.css
     - assets/stylesheets/version-selector.css
+    - assets/stylesheets/ai-overrides.css
 
 extra_javascript:
     - assets/scripts/version-redirect.js


### PR DESCRIPTION
## Summary

After PR #54 was merged and deployed, the new Ask AI button rendered without styles in production. Root cause: Cloudflare keeps `assets/stylesheets/main.css` cached with `max-age=16070400` (~186 days), so the deployment continues to serve the pre-PR `main.css` that does not include `@import _ai-button.css`. The same applies to `_search.css`, whose cached copy still has the old `margin-right: 5rem`.

This PR works around the stale CDN copy by loading the AI button styles (and the search-margin override) from a brand new URL that the CDN has never cached.

## Changes

- New `overrides/assets/stylesheets/ai-overrides.css`: full AI button styles plus `.md-search { margin-right: 0.6rem }` override that wins by cascade order over the stale `_search.css`.
- `extra_css` updated in the root `mkdocs.yml` and in all 7 sub-guides (platform/{user,developer,deployment-on-cloud}, storefront/{user,developer}, marketplace/{user,developer}) to include the new file.

The earlier `_ai-button.css` and the `@import` in `main.css` are left in place: they will start working once the original `main.css` cache eventually expires or is purged.

## Follow-up (out of scope here)

Long-term, static assets without filename-hash should not be served with a 186-day TTL. Either lower the cache-control on CSS to hours, or introduce filename hashing so future edits invalidate cleanly.

## Test plan

- [ ] After deploy, hard-reload any docs page; verify the Ask AI button is fully styled (orange icon, 36px height, hover state).
- [ ] Inspect the loaded stylesheets: `ai-overrides.css` is present and returns 200 fresh from origin.
- [ ] Confirm the search bar margin is tight against the AI button on desktop.
- [ ] Mobile width (≤1050px): only the icon-only mobile button is visible.