### PR TITLE
docs(vc-shell): add components, composables, plugins to nav order

### DIFF
--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/.pages
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/.pages
@@ -3,5 +3,8 @@ nav:
   - introduction
   - getting-started
   - concepts
+  - components
+  - composables
+  - plugins
   - guides
   - reference


### PR DESCRIPTION
## Summary

Update the manual `vc-shell/.pages` nav-list to include the three auto-generated top-level folders that the `sync-docs.yml` CI workflow populates: `components`, `composables`, `plugins`. Restores their position between `concepts` and `guides`.

## ⚠ Merge order

**Must land AFTER the `sync-docs.yml` auto-PR** (created by `vc-shell-docs-bot` with the `auto-generated` label) creates the `components/`, `composables/`, and `plugins/` folders in vc-docs. If this lands first, awesome-pages errors with:

```
NavEntryNotFound: Nav entry "components" not found.
[custom-apps-development/vc-shell/.pages]
```

because `vc-shell/.pages` references folders that don't yet exist on disk.

This PR is intentionally opened as **draft** until the auto-sync lands. Mark ready for review after the first auto-sync PR is merged.

## Final sidebar once all PRs have landed

```
VC-Shell
├── Introduction
├── Getting Started
├── Concepts
├── Components    ← auto from vc-shell sources
├── Composables   ← auto from vc-shell sources
├── Plugins       ← auto from vc-shell sources (new in vc-shell #223)
├── Guides
└── Reference
```

## Related

- Base PR (infrastructure + manual content): #57
- vc-shell PR (merged): VirtoCommerce/vc-shell#223
- Auto-sync PR (created by `sync-docs.yml` after next vc-shell release): TBD

## Test plan

- [ ] Wait for first auto-sync PR to land in main
- [ ] Mark this PR ready for review
- [ ] `mkdocs build` — verify nav resolves; sidebar shows VC-Shell → Components/Composables/Plugins peers
- [ ] CI green