### PR TITLE
docs(vc-shell): restore notifications nav entries after sync

### DIFF
--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/components/data-display/vc-data-table.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/components/data-display/vc-data-table.md
@@ -173,7 +173,7 @@ Formats as currency. Reads the currency code from each row's `currency` field by
 ### Image
 
 ```vue
-<VcColumn id="thumbnail" field="imgSrc" title="Image" type="image" width=\"60px\" />
+<VcColumn id="thumbnail" field="imgSrc" title="Image" type="image" :width="60" />
 ```
 
 Renders a small thumbnail from the field's URL value.
@@ -371,7 +371,7 @@ For explicit control over checkbox column placement:
 
 ```vue
 <VcDataTable :items="products" v-model:selection="selected">
-  <VcColumn id="select" selection-mode="multiple" width=\"40px\" />
+  <VcColumn id="select" selection-mode="multiple" :width="40" />
   <VcColumn id="name" field="name" title="Name" />
 </VcDataTable>
 ```
@@ -505,7 +505,7 @@ A row enters edit mode when the user clicks the edit button. All editable cells 
   <VcColumn id="name" field="name" title="Name" editable />
   <VcColumn id="price" field="price" title="Price" type="money" editable />
   <VcColumn id="stock" field="stock" title="Stock" type="number" editable />
-  <VcColumn id="actions" :row-editor="true" title="" width=\"80px\" />
+  <VcColumn id="actions" :row-editor="true" title="" :width="80" />
 </VcDataTable>
 ```
 
@@ -570,7 +570,7 @@ Columns are resizable by default. Drag the right border of any column header to 
 Set per-column min/max constraints:
 
 ```vue
-<VcColumn id="name" field="name" title="Name" min-width="100px" max-width="400px" />
+<VcColumn id="name" field="name" title="Name" :min-width="100" :max-width="400" />
 ```
 
 ### Reorder
@@ -605,7 +605,7 @@ VcDataTable uses a **weight-based engine** to compute exact pixel widths for eve
 
 | Declaration                     | Meaning                                                      |
 | ------------------------------- | ------------------------------------------------------------ |
-| `width="200"` or `width=\"200px\"` | Initial 200 px hint                                          |
+| `width="200"` or `:width="200"` | Initial 200 px hint                                          |
 | `width="20%"`                   | Initial hint based on 20% of available width                 |
 | `width` omitted                 | Auto — splits remaining space equally among all auto columns |
 
@@ -648,7 +648,7 @@ When a blade narrows (e.g., a second blade opens), only `alwaysVisible` columns 
 
 ```vue
 <VcDataTable :items="products" :show-all-columns="!isBladeNarrow">
-  <VcColumn id="image" field="imgSrc" type="image" width=\"60px\" :always-visible="true" />
+  <VcColumn id="image" field="imgSrc" type="image" :width="60" :always-visible="true" />
   <VcColumn id="name" field="name" title="Name" :always-visible="true" />
   <VcColumn id="price" field="price" title="Price" type="money" />
   <VcColumn id="stock" field="stock" title="Stock" type="number" />
@@ -673,7 +673,7 @@ Enable drag-and-drop row reordering with a drag handle column:
     <VcColumn
       id="drag"
       :row-reorder="true"
-      width=\"40px\"
+      :width="40"
     />
     <VcColumn
       id="name"
@@ -715,7 +715,7 @@ Show additional detail below a row when the user clicks the expand toggle:
     <VcColumn
       id="expand"
       :expander="true"
-      width=\"40px\"
+      :width="40"
     />
     <VcColumn
       id="orderNumber"
@@ -772,7 +772,7 @@ Use `isRowExpandable` to control which rows show the expand toggle. Rows that fa
     <VcColumn
       id="expand"
       :expander="true"
-      width=\"40px\"
+      :width="40"
     />
     <VcColumn
       id="orderNumber"
@@ -1155,7 +1155,7 @@ On mobile screens, VcDataTable automatically switches from a table to a card lay
 
 ```vue
 <VcDataTable :items="products">
-  <VcColumn id="image" field="imgSrc" type="image" mobile-role="image" width=\"60px\" />
+  <VcColumn id="image" field="imgSrc" type="image" mobile-role="image" :width="60" />
   <VcColumn id="name" field="name" title="Name" mobile-role="title" />
   <VcColumn id="price" field="price" title="Price" type="money" mobile-role="field" />
   <VcColumn id="stock" field="stock" title="Stock" type="number" mobile-role="field" />
@@ -1609,7 +1609,7 @@ function onRowRemove(event: { data: Product; index: number; cancel: () => void }
 
 ### Recipe 1: Products List Blade
 
-A typical list blade with search, pagination, row actions, and empty states.
+A typical list blade with search, pagination, row actions, and empty states -- modeled after real vendor-portal usage.
 
 ```vue
 <template>

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/components/feedback/vc-skeleton.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/components/feedback/vc-skeleton.md
@@ -58,7 +58,7 @@ The last row automatically renders at 60% width for a natural paragraph feel.
 ### Avatar Placeholder
 
 ```vue
-<VcSkeleton variant="circle" width=\"48px\" :height="48" />
+<VcSkeleton variant="circle" :width="48" :height="48" />
 ```
 
 <div class="vc-storybook-embed" style="--height: 450px">
@@ -106,7 +106,7 @@ The last row automatically renders at 60% width for a natural paragraph feel.
     >
       <VcSkeleton
         variant="circle"
-        width=\"40px\"
+        :width="40"
         :height="40"
       />
       <div class="tw-flex-1">

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/components/feedback/vc-status-icon.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/components/feedback/vc-status-icon.md
@@ -50,7 +50,7 @@ import { VcStatusIcon } from "@vc-shell/framework";
   <VcColumn
     id="isActive"
     header="Active"
-    width=\"80px\"
+    :width="80"
   >
     <template #default="{ row }">
       <VcStatusIcon :status="row.isActive" />
@@ -70,7 +70,7 @@ import { VcStatusIcon } from "@vc-shell/framework";
     <VcColumn
       id="emailVerified"
       header="Email"
-      width=\"70px\"
+      :width="70"
     >
       <template #default="{ row }">
         <VcStatusIcon :status="row.emailVerified" />
@@ -79,7 +79,7 @@ import { VcStatusIcon } from "@vc-shell/framework";
     <VcColumn
       id="isActive"
       header="Active"
-      width=\"70px\"
+      :width="70"
     >
       <template #default="{ row }">
         <VcStatusIcon :status="row.isActive" />
@@ -88,7 +88,7 @@ import { VcStatusIcon } from "@vc-shell/framework";
     <VcColumn
       id="hasAvatar"
       header="Avatar"
-      width=\"70px\"
+      :width="70"
     >
       <template #default="{ row }">
         <VcStatusIcon :status="!!row.avatarUrl" />

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/components/layout/vc-app.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/components/layout/vc-app.md
@@ -44,7 +44,7 @@ import { VcApp } from "@vc-shell/framework";
 
 const isReady = ref(true);
 const logoUrl = "/logo.svg";
-const appTitle = "Operations Console";
+const appTitle = "Vendor Portal";
 const user = reactive({ name: "John", role: "Admin" });
 </script>
 ```
@@ -148,7 +148,7 @@ Modules registered via `useDynamicModules()` are loaded at runtime. Each module 
 
 The App Hub is a popover panel (desktop) or a swipeable tab (mobile) that combines two sections:
 
-- **Applications** — tile grid of registered apps (for example, Operations Console or Marketplace Admin). Clicking an app switches context without a full page reload. This section can be hidden with `disableAppHub` or customized via the `app-hub` slot. The list is searchable via a built-in search input inside the hub.
+- **Applications** — tile grid of registered apps (e.g., Vendor Portal, Marketplace Admin). Clicking an app switches context without a full page reload. This section can be hidden with `disableAppHub` or customized via the `app-hub` slot. The list is searchable via a built-in search input inside the hub.
 - **Widgets** — registered app bar widgets (notifications, background tasks, etc.). Clicking a widget expands its content inline (desktop) or navigates to its panel (mobile). Widgets are registered via `useAppBarWidget()` and can display badges for unread counts.
 
 On desktop, the App Hub opens from the sidebar header menu button (`AppHubPopover`). On mobile, it appears as a second tab ("Hub") in the slide-out navigation panel — users can swipe between Menu and Hub tabs.

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/components/layout/vc-blade.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/components/layout/vc-blade.md
@@ -11,18 +11,16 @@ The foundational container component of the VirtoCommerce admin shell. Blades ar
 
 Traditional admin panels use page-based routing: click a link, the entire viewport changes. Context is lost. Blades solve this by **stacking panels horizontally**. When a user clicks an item in a list, a details blade slides in from the right while the list remains visible. This preserves context, enables comparison, and supports deep drill-down workflows without losing your place.
 
-```mermaid
-flowchart LR
-    subgraph WS["Products (workspace)"]
-        L1["[list...]<br/>[list...]"]
-    end
-    subgraph CH["Product Details (child blade)"]
-        L2["Name: Widget<br/>SKU: WDG-001"]
-    end
-    subgraph GC["Edit Variant (grandchild blade)"]
-        L3["Color: Red<br/>Size: Large"]
-    end
-    WS --> CH --> GC
+```
++----------------+-------------------+---------------------+
+|                |                   |                     |
+|  Products      |  Product Details  |  Edit Variant       |
+|  (workspace)   |  (child blade)    |  (grandchild blade) |
+|                |                   |                     |
+|  [list...]     |  Name: Widget     |  Color: Red         |
+|  [list...]     |  SKU: WDG-001     |  Size: Large        |
+|                |                   |                     |
++----------------+-------------------+---------------------+
 ```
 
 | Aspect    | Pages/Routes         | Blades                           |
@@ -37,11 +35,18 @@ flowchart LR
 | Scenario                                          | Component                                    |
 | ------------------------------------------------- | -------------------------------------------- |
 | Stacked panel with toolbar, header, and lifecycle | **VcBlade**                                  |
-| One-off confirmation or input dialog              | [VcPopup](../vc-popup/vc-popup.docs.md)      |
+| One-off confirmation or input dialog              | [VcPopup](../../molecules/vc-popup/)         |
 | Full-page route without blade stack               | Vue Router view                              |
-| Scrollable content section inside a blade         | [VcContainer](../../atoms/vc-container/vc-container.docs.md) |
+| Scrollable content section inside a blade         | [VcContainer](../../molecules/vc-container/) |
 
-::storybook id="navigation-vcblade--default"
+<div class="vc-storybook-embed" style="--height: 400px">
+  <iframe
+    src="https://vc-shell-storybook.govirto.com/iframe.html?id=navigation-vcblade--default&viewMode=story"
+    loading="lazy"
+    title="navigation-vcblade--default"
+  ></iframe>
+  <a href="https://vc-shell-storybook.govirto.com/?path=/story/navigation-vcblade--default" target="_blank" rel="noopener">Open in Storybook ↗</a>
+</div>
 
 Use VcBlade for every screen in a vc-shell application -- it is the standard container that integrates with the navigation system, toolbar, breadcrumbs, and unsaved-changes guards. **Do not use** VcBlade for transient dialogs (use `VcPopup` / `usePopup()`) or for content areas that do not need their own header and close button.
 
@@ -59,12 +64,12 @@ Use VcBlade for every screen in a vc-shell application -- it is the standard con
 </template>
 
 <script setup lang="ts">
-defineBlade({ name: "MyFirstBlade", url: "/my-first-blade" });
+defineOptions({ name: "MyFirstBlade", url: "/my-first-blade" });
 </script>
 ```
 
 !!! tip "Every blade needs a name"
-Every blade must define a `name` in `defineBlade`. This is how other blades reference it: `openBlade({ name: "MyFirstBlade" })`. The `url` is optional and controls the URL segment.
+Every blade must define a `name` in `defineOptions`. This is how other blades reference it: `openBlade({ name: "MyFirstBlade" })`. The `url` is optional and controls the URL segment.
 
 ## Blade Anatomy
 
@@ -88,7 +93,7 @@ A blade has four visual zones, rendered top-to-bottom:
 
 **Toolbar** -- Action buttons from the `toolbarItems` prop. Overflow items automatically collapse into a "More" dropdown (via `ResizeObserver`).
 
-**Status Banners** -- Unified, priority-sorted banner area. System banners: yellow when `modified` is `true`, red when the blade has an error (via `setError()`). Custom banners can be added programmatically via `useBlade().addBanner()` — see [useBlade docs](../../../../core/composables/useBlade/useBlade.docs.md#banner-management).
+**Status Banners** -- Unified, priority-sorted banner area. System banners: yellow when `modified` is `true`, red when the blade has an error (via `setError()`). Custom banners can be added programmatically via `useBlade().addBanner()` — see [useBlade docs](../../../core/composables/useBlade/useBlade.docs.md#banner-management).
 
 **Content Area** -- The `default` slot. Scrolls independently of header and toolbar.
 
@@ -118,7 +123,7 @@ import { computed, ref } from "vue";
 import { useBlade, type IBladeToolbar } from "@vc-shell/framework";
 
 // Registration metadata
-defineBlade({
+defineOptions({
   name: "OfferDetails", // Required: unique blade name
   url: "/offer", // Optional: URL segment
   routable: false, // Optional: exclude from direct URL access
@@ -384,7 +389,14 @@ interface IBladeToolbar {
 
 ## Loading State and Skeleton
 
-::storybook id="navigation-vcblade--loading" height="500"
+<div class="vc-storybook-embed" style="--height: 500px">
+  <iframe
+    src="https://vc-shell-storybook.govirto.com/iframe.html?id=navigation-vcblade--loading&viewMode=story"
+    loading="lazy"
+    title="navigation-vcblade--loading"
+  ></iframe>
+  <a href="https://vc-shell-storybook.govirto.com/?path=/story/navigation-vcblade--loading" target="_blank" rel="noopener">Open in Storybook ↗</a>
+</div>
 
 `loading` shows skeleton placeholders for header, toolbar, and content:
 
@@ -425,7 +437,14 @@ useBeforeUnload(hasChanges); // Browser tab close warning
 
 ## Custom Banners
 
-::storybook id="navigation-vcblade--custom-banners" height="500"
+<div class="vc-storybook-embed" style="--height: 500px">
+  <iframe
+    src="https://vc-shell-storybook.govirto.com/iframe.html?id=navigation-vcblade--custom-banners&viewMode=story"
+    loading="lazy"
+    title="navigation-vcblade--custom-banners"
+  ></iframe>
+  <a href="https://vc-shell-storybook.govirto.com/?path=/story/navigation-vcblade--custom-banners" target="_blank" rel="noopener">Open in Storybook ↗</a>
+</div>
 
 Add informational, warning, or success banners to a blade programmatically. Banners appear between the header and toolbar, sorted by severity.
 
@@ -448,12 +467,12 @@ addBanner({
 </script>
 ```
 
-Four variants are available: `danger`, `warning`, `info`, `success`. System banners (error and unsaved changes) are always present and cannot be removed by `clearBanners()`. For the full API reference, see [useBlade — Banner Management](../../../../core/composables/useBlade/useBlade.docs.md#banner-management).
+Four variants are available: `danger`, `warning`, `info`, `success`. System banners (error and unsaved changes) are always present and cannot be removed by `clearBanners()`. For the full API reference, see [useBlade — Banner Management](../../../core/composables/useBlade/useBlade.docs.md#banner-management).
 
 ## Blade Width Control
 
 ```vue
-<VcBlade width=\"350px\">          <!-- Pixels (number) -->
+<VcBlade :width="350">          <!-- Pixels (number) -->
 <VcBlade width="50%">           <!-- CSS value (string) -->
 <VcBlade>                       <!-- Default: "30%" -->
 ```
@@ -464,12 +483,12 @@ On mobile, width is forced to `100%`. When `expanded` is `true`, the blade fills
 
 ### Master-Detail (List + Details)
 
-The most common vc-shell pattern. Key points:
+The most common vc-shell pattern. Key points from real-world usage (see `offers-list.vue` and `offers-details.vue`):
 
 **List blade** -- Opens a details blade on row click, tracks selected item:
 
 ```ts
-defineBlade({ name: "Offers", url: "/offers", isWorkspace: true });
+defineOptions({ name: "Offers", url: "/offers", isWorkspace: true });
 
 const { openBlade } = useBlade();
 const selectedItemId = ref<string>();
@@ -494,7 +513,7 @@ defineExpose({ title: bladeTitle, reload });
 **Details blade** -- Loads entity, saves, notifies parent, replaces self on create:
 
 ```ts
-defineBlade({ name: "Offer", url: "/offer", routable: false });
+defineOptions({ name: "Offer", url: "/offer", routable: false });
 
 const { callParent, replaceWith, onBeforeClose } = useBlade();
 
@@ -578,7 +597,7 @@ const toolbar = ref([
 defineOptions({});
 
 // CORRECT
-defineBlade({ name: "ProductDetails", url: "/product" });
+defineOptions({ name: "ProductDetails", url: "/product" });
 ```
 
 ### Forgetting to expose the title
@@ -631,11 +650,11 @@ openBlade({ name: "ProductsList" });
 | `subtitle`     | `string`           | `undefined` | Secondary text below the title.                              |
 | `icon`         | `string`           | `undefined` | Icon name (e.g., `"lucide-box"`) displayed before the title. |
 | `width`        | `number \| string` | `"30%"`     | Blade width. Numbers are pixels; strings are CSS values.     |
-| `expanded`     | `boolean`          | `undefined` | Whether the blade fills all available width. Inside a blade-navigation context this prop is overridden by the active blade's expanded state; in standalone use the prop is read directly. |
+| `expanded`     | `boolean`          | `false`     | Whether the blade fills all available width.                 |
 | `closable`     | `boolean`          | `true`      | Whether the close button is shown.                           |
 | `toolbarItems` | `IBladeToolbar[]`  | `[]`        | Action buttons in the toolbar zone.                          |
 | `modified`     | `boolean`          | `undefined` | Shows unsaved changes indicator and banner.                  |
-| `loading`      | `boolean`          | `undefined` | Shows skeleton placeholders for all blade zones.             |
+| `loading`      | `boolean`          | `false`     | Shows skeleton placeholders for all blade zones.             |
 
 ## Events
 
@@ -693,36 +712,4 @@ openBlade({ name: "ProductsList" });
 | `usePopup()`                                    | Confirmation dialogs and error messages.                                           |
 | `useBladeWidgets()`                             | Register contextual widgets for the blade widget area.                             |
 
-<!-- internal:start -->
 
-## Content Skeleton Mode
-
-When `loading=true`, VcBlade provides `BladeLoadingKey` to all descendant components via Vue's provide/inject. Each framework UI component automatically renders a skeleton placeholder matching its visual footprint.
-
-### How It Works
-
-1. Set `loading` prop on VcBlade (typically bound to your data-fetching composable's loading ref)
-2. All child components (`VcInput`, `VcSelect`, `VcCard`, etc.) detect the loading state and render skeletons
-3. Layout containers (`VcContainer`, `VcRow`, `VcCol`, `VcForm`) are transparent — they preserve layout structure
-4. When loading completes, components switch to their normal rendering
-
-### What Shows During Loading
-
-- **Config-gated fields** (`v-if="config.showName"`) — config is available immediately, so these fields show skeletons
-- **Data-gated fields** (`v-if="item.productData"`) — data not yet loaded, so these fields don't appear in the skeleton
-- **Header and toolbar** — have their own dedicated skeletons (unchanged)
-
-No changes to existing blade pages are required.
-
-### Custom Components
-
-To make custom components skeleton-aware:
-
-```ts
-import { useBladeLoading } from "@vc-shell/framework";
-
-const bladeLoading = useBladeLoading();
-// bladeLoading.value === true when parent VcBlade is loading
-```
-
-<!-- internal:end -->

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/components/layout/vc-sidebar.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/components/layout/vc-sidebar.md
@@ -139,7 +139,7 @@ Override with the `width` or `height` prop for custom dimensions.
 ### Elevated Variant with Custom Width
 
 ```vue
-<VcSidebar v-model="open" variant="elevated" width=\"480px\" title="Details">
+<VcSidebar v-model="open" variant="elevated" :width="480" title="Details">
   <div class="tw-p-5">Content</div>
 </VcSidebar>
 ```

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/components/misc/vc-badge.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/components/misc/vc-badge.md
@@ -105,7 +105,7 @@ A small indicator component for displaying counts, status dots, or short text la
 ## Recipe: Status Tags in a Table Cell
 
 ```vue
-<VcColumn id="status" header="Status" width=\"120px\">
+<VcColumn id="status" header="Status" :width="120">
   <template #default="{ row }">
     <VcBadge
       inline

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/components/navigation/vc-link.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/components/navigation/vc-link.md
@@ -86,7 +86,7 @@ function openDetails() {
 ### Inline Action in a Table Cell
 
 ```vue
-<VcColumn id="actions" header="Actions" width=\"120px\">
+<VcColumn id="actions" header="Actions" :width="120">
   <template #default="{ row }">
     <div class="tw-flex tw-gap-3">
       <VcLink @click="editItem(row)">Edit</VcLink>

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/blade-navigation/useBlade.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/blade-navigation/useBlade.md
@@ -517,7 +517,7 @@ The most common pattern: a list workspace that opens a details blade on row clic
 <script setup lang="ts">
 import { useBlade } from "@vc-shell/framework";
 
-defineBlade({ name: "ProductsList", url: "/products", isWorkspace: true });
+defineOptions({ name: "ProductsList", url: "/products", isWorkspace: true });
 
 const { openBlade } = useBlade();
 const selectedItemId = ref<string>();
@@ -551,7 +551,7 @@ defineExpose({ reload, title: "Products" });
 <script setup lang="ts">
 import { useBlade, usePopup } from "@vc-shell/framework";
 
-defineBlade({ name: "ProductDetails", url: "/product-details" });
+defineOptions({ name: "ProductDetails", url: "/product-details" });
 
 const { param, onBeforeClose, closeSelf, callParent } = useBlade();
 const { showConfirmation } = usePopup();

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/blade-navigation/useBladeWidgets.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/blade-navigation/useBladeWidgets.md
@@ -117,7 +117,7 @@ A complete example of an external widget that shows an unread message count and 
 **1. Register the external widget (module index.ts):**
 
 ```typescript
-import { registerExternalWidget, BladeDescriptor } from "@vc-shell/framework";
+import { createAppModule, registerExternalWidget, BladeDescriptor } from "@vc-shell/framework";
 import { markRaw } from "vue";
 import { MessageWidget } from "./components/widgets";
 

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/data/useApiClient.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/data/useApiClient.md
@@ -19,7 +19,6 @@ Creates a typed API client instance for communicating with VirtoCommerce platfor
 ## Quick Start
 
 ```typescript
-// pseudo-code: replace OrderClient with your generated API client
 <script setup lang="ts">
 import { useApiClient } from "@vc-shell/framework";
 import { OrderClient } from "@api/orders";
@@ -39,7 +38,6 @@ async function loadOrder(orderId: string) {
 The standard pattern for API calls in blades combines `useApiClient` with `useAsync`. This gives you automatic loading state, error handling, and a clean async action:
 
 ```typescript
-// pseudo-code: replace ProductClient with your generated API client
 <script setup lang="ts">
 import { useApiClient, useAsync } from "@vc-shell/framework";
 import { ProductClient, Product } from "@api/catalog";
@@ -79,7 +77,6 @@ The `loading` ref is `true` while the request is in-flight. The `error` ref capt
 When a blade needs data from multiple platform modules, create multiple client instances using destructuring aliases:
 
 ```typescript
-// pseudo-code: replace these clients with your generated API clients
 <script setup lang="ts">
 import { useApiClient, useAsync } from "@vc-shell/framework";
 import { OrderClient } from "@api/orders";
@@ -107,7 +104,6 @@ const { action: loadOrderDetails } = useAsync(async (orderId: string) => {
 API clients generated from VirtoCommerce platform endpoints follow a consistent search pattern with `SearchCriteria` objects:
 
 ```typescript
-// pseudo-code: replace OrderClient with your generated API client
 <script setup lang="ts">
 import { useApiClient, useAsync } from "@vc-shell/framework";
 import { OrderClient, OrderSearchCriteria, OrderSearchResult } from "@api/orders";
@@ -135,7 +131,6 @@ searchOrders();
 A complete CRUD composable for a domain entity:
 
 ```typescript
-// pseudo-code: replace ProductClient with your generated API client
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
 import { useApiClient, useAsync, useToolbar } from "@vc-shell/framework";

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/notifications/.pages
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/notifications/.pages
@@ -2,5 +2,9 @@
 # To update: edit a *.docs.md in vc-shell, then run yarn docs:sync
 title: Notifications
 nav:
+  - useBladeNotifications: useBladeNotifications.md
+  - useBroadcastFilter: useBroadcastFilter.md
+  - useNotificationContext: useNotificationContext.md
+  - useNotificationStore: useNotificationStore.md
   - useNotifications: useNotifications.md
   - usePopup: usePopup.md

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/notifications/.pages
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/notifications/.pages
@@ -2,9 +2,5 @@
 # To update: edit a *.docs.md in vc-shell, then run yarn docs:sync
 title: Notifications
 nav:
-  - useBladeNotifications: useBladeNotifications.md
-  - useBroadcastFilter: useBroadcastFilter.md
-  - useNotificationContext: useNotificationContext.md
-  - useNotificationStore: useNotificationStore.md
   - useNotifications: useNotifications.md
   - usePopup: usePopup.md

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/services/useDashboard.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/services/useDashboard.md
@@ -269,7 +269,6 @@ export function registerAnalyticsDashboard() {
 ### Widget Component Template
 
 ```typescript
-// pseudo-code: replace OrderClient with your generated API client
 <!-- widgets/OrdersSummary.vue -->
 <script setup lang="ts">
 import { ref, onMounted } from "vue";

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/services/useMenuService.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/services/useMenuService.md
@@ -192,7 +192,6 @@ removeRegisteredMenuItem({ routeId: "ReturnsList" } as MenuItem);
 ### Dynamic Badge Based on API Data
 
 ```typescript
-// pseudo-code: replace OrderClient with your generated API client
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
 import { setMenuBadge, useApiClient } from "@vc-shell/framework";

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/services/useSettings.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/services/useSettings.md
@@ -93,8 +93,8 @@ const { applySettings } = useSettings();
 
 // Override default platform settings with module-specific branding
 applySettings({
-  logo: "/modules/operations-console/logo.svg",
-  title: "Operations Console",
+  logo: "/modules/vendor-portal/logo.svg",
+  title: "Vendor Portal",
 });
 </script>
 ```

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/services/useToolbar.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/services/useToolbar.md
@@ -82,7 +82,6 @@ registerToolbarItem({
 Use `updateToolbarItem` to change any property of a registered button without re-registering it. This is the recommended pattern for toggling disabled state during async operations.
 
 ```typescript
-// pseudo-code: replace OrderClient with your generated API client
 <script setup lang="ts">
 import { watch } from "vue";
 import { useToolbar, useAsync } from "@vc-shell/framework";
@@ -206,7 +205,6 @@ registerToolbarItem({
 ### Complete Blade with Save / Delete / Refresh
 
 ```typescript
-// pseudo-code: replace OrderClient with your generated API client
 <script setup lang="ts">
 import { watch } from "vue";
 import { useToolbar, useAsync, usePermissions, useApiClient } from "@vc-shell/framework";

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/ui-state/useResponsive.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/ui-state/useResponsive.md
@@ -81,7 +81,7 @@ const { openBlade } = useBlade();
         id="image"
         title=""
         type="image"
-        width=\"60px\"
+        :width="60"
         :always-visible="true"
         mobile-role="image"
       />

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/utilities/useAppInsights.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/utilities/useAppInsights.md
@@ -5,7 +5,7 @@
 
 # useAppInsights
 
-Integrates Azure Application Insights page-view tracking with Vue Router and the current user context. This composable bridges the `vue3-application-insights` plugin with the vc-shell framework by automatically enriching every page-view event with the authenticated user's ID and name, generating fresh W3C trace IDs per navigation for distributed tracing, and optionally prefixing page names with the application name (for example, `[Operations Console] Dashboard`).
+Integrates Azure Application Insights page-view tracking with Vue Router and the current user context. This composable bridges the `vue3-application-insights` plugin with the vc-shell framework by automatically enriching every page-view event with the authenticated user's ID and name, generating fresh W3C trace IDs per navigation for distributed tracing, and optionally prefixing page names with the application name (e.g., `[Vendor Portal] Dashboard`).
 
 ## When to Use
 
@@ -51,7 +51,7 @@ export default router;
 
 | Key                     | Type                                     | Description                                                                                       |
 | ----------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `AppInsightsOptionsKey` | `InjectionKey<AppInsightsPluginOptions>` | Optional. Provide this at app level with `{ appName: 'Operations Console' }` to prefix all page names. |
+| `AppInsightsOptionsKey` | `InjectionKey<AppInsightsPluginOptions>` | Optional. Provide this at app level with `{ appName: 'Vendor Portal' }` to prefix all page names. |
 
 ## How It Works
 
@@ -98,12 +98,12 @@ import { AppInsightsOptionsKey } from "@vc-shell/framework";
 const app = createApp(App);
 
 app.provide(AppInsightsOptionsKey, {
-  appName: "Operations Console",
+  appName: "Vendor Portal",
   // ... other AppInsightsPluginOptions
 });
 ```
 
-This results in page names like `[Operations Console] Dashboard` instead of just `Dashboard`.
+This results in page names like `[Vendor Portal] Dashboard` instead of just `Dashboard`.
 
 ## Tips
 

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/utilities/useAsync.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/composables/utilities/useAsync.md
@@ -27,7 +27,6 @@ When the returned `action` is called, `useAsync` automatically:
 ## Quick Start
 
 ```typescript
-// pseudo-code: replace OrderClient with your generated API client
 import { useAsync, useApiClient } from "@vc-shell/framework";
 import { OrderClient } from "@api/orders";
 
@@ -204,7 +203,6 @@ const { action: silentRefresh } = useAsync(
 The standard pattern for API operations in VC-Shell:
 
 ```typescript
-// pseudo-code: replace VcmpSellerCatalogClient with your generated API client
 import { useAsync, useApiClient } from "@vc-shell/framework";
 import { VcmpSellerCatalogClient } from "@api/client";
 
@@ -247,7 +245,6 @@ The standard VC-Shell pattern: encapsulate all CRUD operations for an entity in 
 
 ```typescript
 // composables/useFulfillmentCenter/index.ts
-// pseudo-code: replace VcmpSellerCatalogClient with your generated API client
 import { useApiClient, useAsync, useLoading } from "@vc-shell/framework";
 import { VcmpSellerCatalogClient, type FulfillmentCenter } from "@api/client";
 

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/plugins/extension-points.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/plugins/extension-points.md
@@ -682,4 +682,4 @@ These are used internally by `defineExtensionPoint` and `useExtensionPoint`. You
 | Extension Point Store          | `core/plugins/extension-points/store.ts`           | Reactive registry implementation              |
 | ExtensionPoint Component       | `core/plugins/extension-points/ExtensionPoint.vue` | Declarative render component                  |
 | Types                          | `core/plugins/extension-points/types.ts`           | `ExtensionComponent`, `ExtensionPointOptions` |
-| Seller Details (usage example) | Generated seller details module                    | Extension point host                          |
+| Seller Details (usage example) | `apps/vendor-portal/src/modules/seller-details/`   | Real-world extension point host               |

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/plugins/modularity.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/plugins/modularity.md
@@ -18,6 +18,7 @@ If you are building anything in vc-shell -- a new page, a CRUD flow, a dashboard
 - Every vc-shell feature starts here -- `defineAppModule()` is the entry point for all module development
 - When NOT to use: for shared utilities or composables that have no UI -- export them as plain TypeScript modules instead
 
+---
 
 ## Table of Contents
 
@@ -34,8 +35,8 @@ If you are building anything in vc-shell -- a new page, a CRUD flow, a dashboard
   - [Registering Notification Types](#registering-notification-types)
   - [Adding Locales](#adding-locales)
   - [Registering Dashboard Widgets](#registering-dashboard-widgets)
-  - [Plugin Compatibility](#plugin-compatibility)
-  - [Plugin Loading (Module Federation)](#plugin-loading-module-federation)
+  - [Module Version Compatibility](#module-version-compatibility)
+  - [Remote Modules (Module Federation)](#remote-modules-module-federation)
 - [Recipes](#recipes)
   - [Minimal Module (Blades Only)](#minimal-module-blades-only)
   - [Module with CRUD Blades (List + Details)](#module-with-crud-blades-list--details)
@@ -45,6 +46,7 @@ If you are building anything in vc-shell -- a new page, a CRUD flow, a dashboard
 - [API Reference](#api-reference)
 - [Related](#related)
 
+---
 
 ## Quick Start
 
@@ -65,15 +67,24 @@ export default defineAppModule({
 ```vue
 <!-- modules/my-feature/pages/MyFeatureList.vue -->
 <template>
-  <VcBlade title="My Feature">
+  <VcBlade
+    title="My Feature"
+    :closable="closable"
+    @close="$emit('close:blade')"
+  >
     <p>Hello from my first module!</p>
   </VcBlade>
 </template>
 
 <script setup lang="ts">
-import { VcBlade } from "@vc-shell/framework/ui";
+import { VcBlade } from "@vc-shell/framework";
 
-defineBlade({
+defineProps<{ closable?: boolean }>();
+defineEmits(["close:blade"]);
+</script>
+
+<script lang="ts">
+defineOptions({
   name: "MyFeatureList",
   url: "/my-feature",
   isWorkspace: true,
@@ -85,8 +96,6 @@ defineBlade({
 });
 </script>
 ```
-
-`VcBlade` reads `expanded` and `closable` directly from the blade descriptor and emits its own close action — blade pages no longer declare those as props or wire up `@close` / `@expand` / `@collapse` emits.
 
 ```json
 // modules/my-feature/locales/en.json
@@ -104,6 +113,7 @@ The module is installed by the host application (or loaded remotely via Module F
 3. Adds "My Feature" to the sidebar menu
 4. Merges English locale strings into vue-i18n
 
+---
 
 ## Concepts
 
@@ -141,12 +151,31 @@ my-feature-module/
 
 When the host application calls `app.use(module)`, the `install()` function runs the following steps **synchronously and in order**:
 
-```mermaid
-flowchart TD
-    Entry["app.use(module)"] --> S1["1. BLADE REGISTRATION<br/>For each entry in <code>blades</code>:<br/>• Register in BladeRegistry (name, component, route, permissions)<br/>• If blade has <code>url</code> + <code>menuItem</code> → register sidebar menu entry"]
-    S1 --> S2["2. NOTIFICATION REGISTRATION<br/>For each entry in <code>notifications</code>:<br/>• Register type + config in NotificationStore"]
-    S2 --> S3["3. LEGACY NOTIFICATION COMPAT (deprecated)<br/>If <code>notifications</code> is NOT provided but <code>notificationTemplates</code> is:<br/>• Register templates with notifyType<br/>If any blade has <code>notifyType</code>:<br/>• Create automatic toast subscription (with deprecation warning)"]
-    S3 --> S4["4. LOCALE MERGE<br/>For each entry in <code>locales</code>:<br/>• mergeLocaleMessage(langCode, messages) into vue-i18n"]
+```
+app.use(module)
+  |
+  v
+1. BLADE REGISTRATION
+   For each entry in `blades`:
+     - Register in BladeRegistry (name, component, route, permissions)
+     - If blade has `url` + `menuItem` --> register sidebar menu entry
+  |
+  v
+2. NOTIFICATION REGISTRATION (new API)
+   For each entry in `notifications`:
+     - Register type + config in NotificationStore
+  |
+  v
+3. LEGACY NOTIFICATION COMPAT (deprecated)
+   If `notifications` is NOT provided but `notificationTemplates` is:
+     - Register templates with notifyType in NotificationStore
+   If any blade has `notifyType`:
+     - Create automatic toast subscription (with deprecation warning)
+  |
+  v
+4. LOCALE MERGE
+   For each entry in `locales`:
+     - mergeLocaleMessage(langCode, messages) into vue-i18n
 ```
 
 > **Why this order matters:** Blades must be registered before anything references them (e.g., menu items link to blade routes). Notifications are independent. Locales come last because they are purely additive.
@@ -187,6 +216,7 @@ export default createAppModule(pages, locales);
 export default defineAppModule({ blades: pages, locales });
 ```
 
+---
 
 ## Features
 
@@ -242,15 +272,15 @@ Each blade is registered in the `BladeRegistry` with:
 | `routable`    | `component.routable`               | `true` = gets a Vue Router route (default: `true`) |
 | `permissions` | `component.permissions`            | Required permissions to access the blade           |
 
-> **Tip:** The export key (e.g., `ProductsList` in `{ ProductsList }`) is used as a fallback name when `defineBlade` does not set a name. Always set `defineBlade({ name: "..." })` explicitly.
+> **Tip:** The export key (e.g., `ProductsList` in `{ ProductsList }`) is used as a fallback name when `component.name` is not defined. Always set `defineOptions({ name: "..." })` for clarity.
 
 ### Blade Static Properties
 
-Blades declare their routing, permissions, and menu behavior through `defineBlade`:
+Blades declare their routing, permissions, and menu behavior through **static properties** set via `defineOptions`:
 
 ```vue
-<script setup lang="ts">
-defineBlade({
+<script lang="ts">
+defineOptions({
   // REQUIRED: Unique name for the blade (used in BladeRegistry)
   name: "OrdersList",
 
@@ -278,13 +308,13 @@ defineBlade({
 </script>
 ```
 
-> **Note:** `defineBlade` is compiled by the VC-Shell Vite plugin. It emits Vue component options and registers blade metadata before module installation.
+> **Note:** `defineOptions` is a Vue 3.3+ compiler macro. Static properties like `url`, `isWorkspace`, and `menuItem` are vc-shell conventions -- they are read by `defineAppModule` during the install phase, not by Vue itself.
 
 **Child blades** (detail pages opened from a list) typically do NOT need `url`, `isWorkspace`, or `menuItem`:
 
 ```vue
-<script setup lang="ts">
-defineBlade({
+<script lang="ts">
+defineOptions({
   name: "OrderDetails",
   // No url, no menuItem -- this blade is opened programmatically via openBlade()
 });
@@ -296,8 +326,8 @@ defineBlade({
 Menu items are created **automatically** when a blade has both `url` and `menuItem` static properties. You do not call any menu API yourself.
 
 ```vue
-<script setup lang="ts">
-defineBlade({
+<script lang="ts">
+defineOptions({
   name: "ProductsList",
   url: "/products",
   isWorkspace: true,
@@ -477,34 +507,68 @@ export default defineAppModule({ blades: pages, locales });
 | `permissions` | `string[]`                          | Required permissions (optional)          |
 | `props`       | `Record<string, unknown>`           | Props passed to the component (optional) |
 
-### Plugin Compatibility
+### Module Version Compatibility
 
-Plugin compatibility is settled on the Platform side, not in the browser. The Platform validates each plugin's `<dependency>` declarations in **module.manifest** at .NET module install time and refuses incompatible installs. By the time a plugin appears in the manifest endpoint, the dependency graph has already approved it — there is no client-side semver filter.
+Remote modules loaded via Module Federation can declare framework compatibility using semver ranges. The host checks these ranges at load time and skips incompatible modules:
 
-Upgrading the host's framework does not silently drop older plugins; if a plugin becomes incompatible, the Platform admin sees an install-time error first.
+```json
+// Remote module's manifest (served by the backend)
+{
+  "id": "my-remote-module",
+  "entry": "https://cdn.example.com/my-module/remoteEntry.js",
+  "version": "1.2.0",
+  "compatibleWith": {
+    "dependencies": {
+      "@vc-shell/framework": ">=2.0.0 <3.0.0"
+    }
+  }
+}
+```
 
-### Plugin Loading (Module Federation)
+At startup, the host:
 
-vc-shell loads plugin extensions at runtime via Module Federation. A plugin remote is built by a .NET module's Vue subpackage and discovered by the Platform from the dependency graph. The host fetches a manifest of plugins for its `appId` at boot and installs each as a Vue plugin.
+1. Reads the current `@vc-shell/framework` version from `package.json`
+2. Checks each remote module's `compatibleWith.dependencies["@vc-shell/framework"]` range
+3. Skips modules that fail the semver check (with a console warning)
+4. Loads and installs compatible modules
+
+This ensures that a framework major version upgrade does not break deployed remote modules.
+
+### Remote Modules (Module Federation)
+
+vc-shell supports loading modules from remote servers at runtime using Module Federation. This is the primary deployment model for production applications where modules are developed and deployed independently.
 
 The loading sequence:
 
-```mermaid
-flowchart TD
-    A["App Start (host main.ts)"] --> N1["1. Fetch plugin manifest<br/>GET /api/apps/{appId}/manifest"]
-    N1 --> N2["2. Initialize MF runtime<br/>with shared deps from @vc-shell/mf-config"]
-    N2 --> N3["3. Load each plugin's remoteEntry.js<br/>(Promise.allSettled in parallel)"]
-    N3 --> N4["4. Resolve Vue plugins from each remote's default export"]
-    N4 --> N5["5. app.use(plugin, { router }) for each<br/>→ triggers defineAppModule's install()"]
-    N5 --> N6["6. provide(ModulesReadyKey, true)<br/>→ app.mount('#app')"]
 ```
-
-Non-OK manifest responses (401 / 403 / 404 / 5xx) are treated as "no plugins" — the host logs a `console.warn`, sets `modulesReady=true`, and mounts without extensions. Only network or parse failures set `modulesLoadError=true`.
-
-See the [Module Federation guide](../guides/module-federation/index.md) for the full plugin-author + host-app walkthrough.
+App Start
+  |
+  v
+1. Fetch module registry from /api/frontend-modules
+  |
+  v
+2. Filter by framework version compatibility (semver check)
+  |
+  v
+3. Initialize Module Federation runtime with shared deps
+   (vue, vue-router, vue-i18n, @vc-shell/framework, etc.)
+  |
+  v
+4. Load all compatible remote modules in parallel
+  |
+  v
+5. Resolve Vue plugins from each module's exports
+  |
+  v
+6. app.use(plugin) for each module --> triggers defineAppModule's install()
+  |
+  v
+7. Set modulesReady = true --> app renders
+```
 
 The host shares singleton instances of core dependencies (Vue, Vue Router, vue-i18n, @vc-shell/framework) so that remote modules use the same runtime. This is critical for reactivity, routing, and DI to work across module boundaries.
 
+---
 
 ## Recipes
 
@@ -560,12 +624,8 @@ The list blade (workspace):
 
 ```vue
 <!-- pages/ProductsList.vue -->
-<script setup lang="ts">
-import { useBlade } from "@vc-shell/framework";
-import { VcBlade, VcDataTable, VcColumn } from "@vc-shell/framework/ui";
-import useProducts from "../composables/useProducts";
-
-defineBlade({
+<script lang="ts">
+defineOptions({
   name: "ProductsList",
   url: "/products",
   isWorkspace: true,
@@ -576,6 +636,11 @@ defineBlade({
     priority: 10,
   },
 });
+</script>
+
+<script setup lang="ts">
+import { useBlade, VcBlade, VcDataTable, VcColumn } from "@vc-shell/framework";
+import useProducts from "../composables/useProducts";
 
 const { openBlade } = useBlade();
 const { items, loading, totalCount, load } = useProducts();
@@ -593,13 +658,15 @@ The details blade (child):
 
 ```vue
 <!-- pages/ProductDetails.vue -->
-<script setup lang="ts">
-import { VcBlade } from "@vc-shell/framework/ui";
-
-defineBlade({
+<script lang="ts">
+defineOptions({
   name: "ProductDetails",
   // No url, no menuItem -- opened programmatically
 });
+</script>
+
+<script setup lang="ts">
+import { VcBlade } from "@vc-shell/framework";
 
 const props = defineProps<{
   param?: { productId: string };
@@ -641,7 +708,7 @@ export default defineAppModule({});
 
 ### Module Extending Another Module
 
-A module can extend another module's UI by using extension points (see the [Extension Points Plugin](../extension-points/extension-points.docs.md)):
+A module can extend another module's UI by using extension points (see the [Extension Points Plugin](./extension-points.md)):
 
 ```typescript
 // modules/marketplace-commissions/index.ts
@@ -685,10 +752,11 @@ import { ExtensionPoint } from "@vc-shell/framework";
 </script>
 ```
 
+---
 
 ## Common Mistakes
 
-### Forgetting `defineBlade` on a blade
+### Forgetting `defineOptions` on a blade
 
 ```typescript
 // module/index.ts
@@ -700,11 +768,11 @@ export default defineAppModule({
 ```vue
 <!-- MyBlade.vue -->
 <script setup lang="ts">
-// No defineBlade!
+// No defineOptions!
 </script>
 ```
 
-The blade will be registered with the export key (`"MyBlade"`) as its name, but it will have **no route and no menu entry** because `defineBlade` is what writes routing, permissions, and menu config into the blade config registry. Always call `defineBlade({ name, url?, menuItem?, ... })` at the top of `<script setup>`.
+The blade will be registered with the export key (`"MyBlade"`) as its name, but it will have **no route and no menu entry**. Always add `defineOptions` with at least a `name`.
 
 ### Using `createAppModule` with the new notifications API
 
@@ -751,11 +819,11 @@ export default defineAppModule({
 
 // Module B
 export default defineAppModule({
-  blades: { Dashboard: DashboardB }, // Throws at install time!
+  blades: { Dashboard: DashboardB }, // Overwrites Module A's Dashboard!
 });
 ```
 
-`BladeRegistry` throws when a name is registered twice: `Blade 'Dashboard' is already registered`. The error halts module installation, so duplicate names are caught at startup rather than silently shadowing each other. Use descriptive, module-prefixed names: `OrdersDashboard`, `ProductsDashboard`.
+Blade names must be globally unique. Use descriptive, module-prefixed names: `OrdersDashboard`, `ProductsDashboard`.
 
 ### Locale key collisions
 
@@ -769,6 +837,7 @@ export default defineAppModule({
 
 Always namespace locale keys under your module name: `ORDERS.ACTIONS.SAVE`, `PRODUCTS.ACTIONS.SAVE`.
 
+---
 
 ## API Reference
 
@@ -796,6 +865,7 @@ interface DefineAppModuleOptions {
 
 **Returns:** `{ install(app: App): void }` -- a standard Vue plugin.
 
+---
 
 ### `createAppModule(pages, locales?, notificationTemplates?, components?): Plugin`
 
@@ -810,6 +880,7 @@ interface DefineAppModuleOptions {
 | 3   | `notificationTemplates` | `Record<string, Component>`                | Legacy notification templates (optional)          |
 | 4   | `components`            | `Record<string, Component>`                | Global components (optional, ignored in new impl) |
 
+---
 
 ### `registerDashboardWidget(widget): void`
 
@@ -827,6 +898,7 @@ interface DashboardWidget {
 }
 ```
 
+---
 
 ### Blade Static Properties (defineOptions)
 
@@ -848,6 +920,7 @@ interface DashboardWidget {
 | `priority`    | `number`   | Sort order (lower = higher in menu)                             |
 | `permissions` | `string[]` | Permission override (optional, falls back to blade permissions) |
 
+---
 
 ### `NotificationTypeConfig`
 
@@ -876,6 +949,7 @@ interface ToastConfig {
 }
 ```
 
+---
 
 ## Related
 

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/plugins/notifications.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/plugins/notifications.md
@@ -22,18 +22,21 @@ The notification system receives `PushNotification` messages from the platform S
 
 ## Architecture
 
-```mermaid
-flowchart TD
-    H["PushNotification (SignalR hub)"] --> S["Send<br/>(targeted)"]
-    H --> B["SendSystemEvents<br/>(broadcast)"]
-    B --> F{"broadcastFilter?"}
-    F -->|accept| I["NotificationStore.ingest()"]
-    F -->|reject| X["dropped"]
-    S --> I
-    I --> Hist["history[]<br/>(persistent, loaded from API)"]
-    I --> RT["realtime[]<br/>(session-only)"]
-    I --> Toast["ToastController.handle()<br/>Level 1: always-on"]
-    I --> Sub["subscriber callbacks<br/>Level 2: blade-scoped"]
+```
+PushNotification (SignalR)
+        |
+  ┌─────┴─────┐
+  Send     SendSystemEvents
+  |            |
+  |     broadcastFilter?
+  |            |
+  v            v
+  NotificationStore.ingest()
+        |
+        +---> history[]  (persistent, loaded from API)
+        +---> realtime[] (session-only, from SignalR)
+        +---> ToastController.handle()   [Level 1: always-on]
+        +---> subscriber callbacks        [Level 2: blade-scoped]
 ```
 
 ## API
@@ -240,13 +243,4 @@ await store.markAllAsRead(); // optimistic update with rollback on failure
 - `framework/shared/components/notifications/` -- Notification dropdown UI
 - `framework/core/api/platform.ts` -- `PushNotification`, `PushNotificationClient`
 
-<!-- internal:start -->
 
-## Internal Files
-
-- `framework/core/notifications/store.ts` -- `NotificationStore` implementation
-- `framework/core/notifications/toast-controller.ts` -- Toast lifecycle management
-- `framework/core/notifications/composables/` -- `useNotificationStore`, `useBladeNotifications`, `useNotificationContext`, `useBroadcastFilter`
-- `framework/core/notifications/types.ts` -- All notification type definitions
-
-<!-- internal:end -->

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/plugins/signalr.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/plugins/signalr.md
@@ -65,26 +65,26 @@ Module developers do not install this plugin. It is registered once by the frame
 
 ## Connection Lifecycle
 
-```mermaid
-sequenceDiagram
-    participant U as User
-    participant C as SignalR client
-    participant Hub as /pushNotificationHub
-    participant Store as NotificationStore
-
-    U->>C: log in (isAuthenticated = true)
-    C->>Hub: connection.start() (WebSocket)
-    Note over C,Hub: connection open
-
-    Hub-->>C: "Send" (targeted)
-    C->>Store: ingest(message)
-    Hub-->>C: "SendSystemEvents" (broadcast, filtered by creator)
-    C->>Store: ingest(message, { broadcast: true })
-
-    Store->>Store: toast • subscriber callbacks • history update
-
-    U->>C: log out
-    C->>Hub: connection.stop()
+```
+User logs in (isAuthenticated = true)
+  |
+  v
+connection.start()  ------>  /pushNotificationHub (WebSocket)
+  |                              |
+  |  <--- "Send" messages -------+
+  |  <--- "SendSystemEvents" ----+  (filtered by creator)
+  |                              |
+  v                              |
+store.ingest(message)            |
+  |                              |
+  +--- toast notification        |
+  +--- subscriber callbacks      |
+  +--- history update            |
+  |                              |
+User logs out                    |
+  |                              |
+  v                              |
+connection.stop()  ------------>-+
 ```
 
 ### Reconnection Behavior

--- a/platform/developer-guide/docs/custom-apps-development/vc-shell/reference/api/platform-client.md
+++ b/platform/developer-guide/docs/custom-apps-development/vc-shell/reference/api/platform-client.md
@@ -159,8 +159,8 @@ You do not need to manually set the auth token on client instances. The `useApiC
 Do not import from the `platform.ts` file path directly. Always import from `@vc-shell/framework` to ensure proper module resolution and tree-shaking:
 
 ```typescript
-// Bad: direct file path
-"@core/api/platform";
+// Bad: direct file import
+import { SecurityClient } from "@core/api/platform";
 
 // Good: framework re-export
 import { SecurityClient } from "@vc-shell/framework";


### PR DESCRIPTION
## Summary

The upstream `docs:sync` generator rebuilds `composables/notifications/.pages` from its own registry, which only lists `useNotifications` and `usePopup`. The four other composables in that folder — `useBladeNotifications`, `useBroadcastFilter`, `useNotificationContext`, `useNotificationStore` — exist as auto-generated `.md` files but are missing from the upstream nav index, so every sync drops their entries.

Re-add the four entries.

Merge **after** #64 lands so the additions are visible in the diff.

## Follow-up

Upstream fix needed in `vc-shell/cli/docs-sync` to discover these composables and emit them automatically.