### PR TITLE
fix(ci): fail docs deploy when downstream cloud deploy fails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,9 @@ jobs:
           dockerPwd: ${{ secrets.VCPT_DOCKER_PASSWORD }}
 
       - name: Trigger cloud deploy
+        id: dispatch
         run: |
+          echo "dispatched-at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
           gh api repos/VirtoCommerce/vc-github-actions/dispatches \
             -f event_type=deploy-docs \
             -f "client_payload[image_tag]=${{ steps.build.outputs.docker-image-tag }}" \
@@ -41,3 +43,38 @@ jobs:
           echo "✅ Dispatched cloud deploy for ${{ steps.build.outputs.docker-image-tag }}"
         env:
           GH_TOKEN: ${{ secrets.REPO_TOKEN }}
+
+      - name: Wait for cloud deploy
+        timeout-minutes: 30
+        run: |
+          set -euo pipefail
+
+          # 1. Find the downstream run spawned by the dispatch above.
+          run_id=""
+          for attempt in $(seq 1 30); do
+            run_id=$(gh run list -R VirtoCommerce/vc-github-actions \
+              --workflow "Deploy docs to VC Cloud" \
+              --event repository_dispatch \
+              --created ">=$DISPATCHED_AT" \
+              --limit 1 \
+              --json databaseId --jq '.[0].databaseId // empty')
+            [ -n "$run_id" ] && break
+            sleep 10
+          done
+          if [ -z "$run_id" ]; then
+            echo "::error::Cloud deploy run never appeared in VirtoCommerce/vc-github-actions within 5 minutes. The deploy-docs dispatch may have been lost."
+            exit 1
+          fi
+
+          run_url="https://github.com/VirtoCommerce/vc-github-actions/actions/runs/$run_id"
+          echo "Watching cloud deploy: $run_url"
+
+          # 2. Fail this workflow if the downstream deploy fails.
+          if ! gh run watch "$run_id" -R VirtoCommerce/vc-github-actions --interval 30 --exit-status; then
+            echo "::error::Cloud deploy FAILED. The docs image was built and pushed, but prod was NOT updated. Inspect: $run_url"
+            exit 1
+          fi
+          echo "✅ Cloud deploy succeeded: $run_url"
+        env:
+          GH_TOKEN: ${{ secrets.REPO_TOKEN }}
+          DISPATCHED_AT: ${{ steps.dispatch.outputs.dispatched-at }}

--- a/versioned-build-cicd.py
+++ b/versioned-build-cicd.py
@@ -261,15 +261,15 @@ def main():
     # This builds only the main page + redirects, without rebuilding all subsites
     # Search index will be merged from versioned subsite indexes later
     print("  Building root site (without monorepo)...")
-    run_command("mkdocs build -f mkdocs.yml -d " + args.output_dir, check=False)
+    run_command("mkdocs build -f mkdocs.yml -d " + args.output_dir)
 
     # Build intermediate landing pages (platform, marketplace, storefront)
     # Using mkdocs.yml configs which override plugins to exclude redirects
     # This prevents generating hundreds of redirect HTML files
     print("  Building intermediate landing pages...")
-    run_command(f"mkdocs build -f storefront/mkdocs.yml -d ../{args.output_dir}/storefront", check=False)
-    run_command(f"mkdocs build -f platform/mkdocs.yml -d ../{args.output_dir}/platform", check=False)
-    run_command(f"mkdocs build -f marketplace/mkdocs.yml -d ../{args.output_dir}/marketplace", check=False)
+    run_command(f"mkdocs build -f storefront/mkdocs.yml -d ../{args.output_dir}/storefront")
+    run_command(f"mkdocs build -f platform/mkdocs.yml -d ../{args.output_dir}/platform")
+    run_command(f"mkdocs build -f marketplace/mkdocs.yml -d ../{args.output_dir}/marketplace")
 
     print("✅ Non-versioned landing pages built (subsites will come from gh-pages)")
 
@@ -286,7 +286,9 @@ def main():
         "storefront/user-guide": args.version,
     }
 
-    # Deploy each subsite
+    # Deploy each subsite; collect failures so one broken subsite
+    # cannot silently produce a partial site image.
+    failed_subsites = []
     for subsite, version in subsites.items():
         if not version:
             print(f"  ⚠️  Skipping {subsite} (no version specified)")
@@ -316,14 +318,24 @@ def main():
         result = run_command(" ".join(mike_cmd), check=False)
         if result.returncode != 0:
             print(f"❌ Mike deploy failed for {subsite}: {result.stderr}")
-            print("This might cause deployment issues!")
+            failed_subsites.append(subsite)
+            continue
 
         # Set as default if requested
         if args.set_as_default:
             print(f"  Setting {subsite} as default...")
-            run_command(f'mike set-default -F "{config}" --deploy-prefix "{subsite}" {version} --push', check=False)
+            result = run_command(f'mike set-default -F "{config}" --deploy-prefix "{subsite}" {version} --push', check=False)
+            if result.returncode != 0:
+                print(f"❌ Mike set-default failed for {subsite}: {result.stderr}")
+                failed_subsites.append(subsite)
+                continue
 
         print(f"  ✅ {subsite} deployed")
+
+    if failed_subsites:
+        print(f"❌ Mike deploy failed for {len(failed_subsites)} subsite(s): {', '.join(failed_subsites)}")
+        print("Aborting before image build to avoid shipping a broken site.")
+        sys.exit(1)
 
     print("✅ Versioned subsites deployed")
 


### PR DESCRIPTION
## Problem

Two layers of silent failure hid a broken deploy for 5 days:

1. **versioned-build-cicd.py swallowed build errors.** Every `mkdocs build` and `mike deploy` ran with `check=False`. After the awesome-nav migration (#70), all 7 subsites failed with `The "awesome-nav" plugin is not installed` (the composite action installs a hardcoded pip list, see VirtoCommerce/vc-github-actions#246), yet the script printed "✓ Deployment completed" and a broken image was pushed.
2. **The "Deploy versioned docs" workflow reported success after dispatching** the `deploy-docs` event, regardless of what happened to the actual cloud rollout. The broken image never passed the ArgoCD health check ([failed run](https://github.com/VirtoCommerce/vc-github-actions/actions/runs/26744412924), exit 124, pods stuck in `Progressing`/`Degraded`), and prod silently stayed on the May 28 image.

## Fix

**versioned-build-cicd.py:**
- Landing-page `mkdocs build` calls use the default `check=True` and abort on error.
- `mike deploy` / `mike set-default` failures are collected per subsite; any failure aborts the script before the Docker image is built.

**deploy.yml — new "Wait for cloud deploy" step:**
1. Polls `vc-github-actions` for the `Deploy docs to VC Cloud` run created by our dispatch (up to 5 minutes).
2. Watches it to completion with `gh run watch --exit-status` (step capped at 30 minutes).
3. Fails this workflow with an `::error::` annotation and a direct link to the downstream run when the rollout fails or never appears.

Result: a broken plugin set fails the build step; a failed rollout fails the deploy workflow. Either way the commit turns red in this repo instead of requiring cross-repo archaeology.

Companion PR: VirtoCommerce/vc-github-actions#246 (install pinned deps from requirements-docs.txt — the actual root-cause fix).