### PR TITLE
fix(build): preserve per-version assets when deduplicating (fixes unstyled non-latest doc versions)

### DIFF
--- a/versioned-build-cicd.py
+++ b/versioned-build-cicd.py
@@ -156,13 +156,30 @@ def run_command(cmd, check=True, cwd=None):
     return result
 
 
+def list_relative_files(folder):
+    """Return the set of file paths under folder, relative to folder."""
+    files = set()
+    for dirpath, _, filenames in os.walk(folder):
+        for filename in filenames:
+            files.add(os.path.relpath(os.path.join(dirpath, filename), folder))
+    return files
+
+
 def deduplicate_assets(site_dir):
     """
     Replace duplicate MkDocs theme assets folders with symlinks to the root assets.
 
     MkDocs Material theme copies ~11MB of assets (CSS, JS, fonts, icons) into each
-    subsite build. With 10+ subsites, this adds ~100MB+ of duplicate content.
-    This function replaces all nested assets/ folders with symlinks to the root assets/.
+    subsite build. With 10+ subsites, this adds ~100MB+ of duplicate content, so
+    nested assets/ folders are replaced with symlinks to the root assets/.
+
+    IMPORTANT: only deduplicate a nested assets/ folder when every file in it also
+    exists in the root assets/. Material uses content-hashed asset filenames
+    (e.g. main.<hash>.min.css); a mike version built with a different Material
+    release carries a DIFFERENT hash. Blindly symlinking such a folder to the root
+    assets/ (built with the current Material) would hide that version's stylesheets,
+    so its pages reference a hash that no longer exists and load unstyled. Folders
+    whose files are not a subset of the root assets/ are kept as real files.
     """
     root_assets = os.path.join(site_dir, "assets")
 
@@ -170,8 +187,13 @@ def deduplicate_assets(site_dir):
         print("    ⚠️  Root assets folder not found, skipping deduplication")
         return 0, 0
 
+    # Files available in the root assets/ (relative paths). A nested folder can
+    # only be safely symlinked here if all of its files are present in this set.
+    root_files = list_relative_files(root_assets)
+
     replaced_count = 0
     freed_bytes = 0
+    kept_count = 0
 
     for root, dirs, _ in os.walk(site_dir, topdown=True):
         if "assets" in dirs and root != site_dir:
@@ -179,6 +201,16 @@ def deduplicate_assets(site_dir):
 
             # Skip if already a symlink
             if os.path.islink(assets_path):
+                continue
+
+            rel_assets = os.path.relpath(assets_path, site_dir)
+
+            # Keep version-specific assets that the root assets/ does not contain
+            # (e.g. an older Material build's content-hashed stylesheets).
+            nested_files = list_relative_files(assets_path)
+            if not nested_files.issubset(root_files):
+                kept_count += 1
+                print(f"    Kept {rel_assets}/ (version-specific assets differ from root)")
                 continue
 
             # Calculate size before removal
@@ -194,8 +226,10 @@ def deduplicate_assets(site_dir):
 
             replaced_count += 1
             # Print relative path from site_dir for cleaner output
-            rel_assets = os.path.relpath(assets_path, site_dir)
             print(f"    Symlinked {rel_assets}/ -> {rel_path}")
+
+    if kept_count:
+        print(f"    Kept {kept_count} version-specific assets folder(s) intact")
 
     return replaced_count, freed_bytes
 


### PR DESCRIPTION
## Problem

Non-latest mike doc versions lost all styling in prod (e.g. `https://docs.virtocommerce.org/platform/user-guide/2.0/`). Their HTML referenced a content-hashed stylesheet (`main.484c7ddc.min.css`) that was absent from the image, so the server returned the SPA/index fallback (`200` + `content-type: text/html`) and the browser ignored it as CSS.

## Root cause

`versioned-build-cicd.py` → `deduplicate_assets()` replaced **every** nested `assets/` folder with a symlink to the root `assets/` (the current build, e.g. hash `6543a935`).

Material uses content-hashed asset filenames. A mike version built earlier with a different Material release carries a **different** hash. Symlinking that version's `assets/` to the current-build root `assets/` hid its stylesheets, so its pages pointed at a hash that no longer existed → unstyled pages.

This is also why a future `mkdocs-material` bump on `main` would silently re-break every older version: a `main` deploy rebuilds only the latest version, but the dedup step collapses all versions onto the new root hash.

## Fix

Only deduplicate a nested `assets/` folder when **all of its files are also present in the root `assets/`**. Folders with version-specific files (an older Material build's hashed assets) are kept as real files.

- Same-build subsites still get symlinked → the ~100MB space saving is preserved.
- Cross-version (different Material) assets are preserved → no more 404s / unstyled old versions, even across Material upgrades.

## Verification

Unit-tested the function on a synthetic tree (root + a same-hash 3.0 folder + an old-hash 2.0 folder):

- 3.0 `assets/` → symlinked (deduplicated) ✅
- 2.0 `assets/` → kept as real files; old-hash CSS still present ✅
- root `assets/` intact ✅

All three live versions (1.0/2.0/3.0) currently serve `content-type: text/css` after the manual per-branch redeploys; this change makes that resilient to future Material upgrades without per-branch redeploys.

Refs VirtoCommerce/vc-github-actions#247
