### PR TITLE
Fix version-selector title casing (Stable, not STABLE)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
       - 'release/**'
+  # Manual trigger: rebuild and redeploy the prod image from the selected branch.
+  # Run on `main` to refresh the non-versioned landing pages (/, /platform/, ...),
+  # which are baked into the prod image only from `main`.
+  workflow_dispatch:
 
 concurrency:
   group: docs-deploy-${{ github.ref }}
@@ -32,8 +36,17 @@ jobs:
           dockerUsr: ${{ secrets.VCPT_DOCKER_USER }}
           dockerPwd: ${{ secrets.VCPT_DOCKER_PASSWORD }}
 
+      # Only `main` updates the live prod image. The image build above bakes in
+      # the non-versioned landing pages (/, /platform/, /storefront/, /marketplace/)
+      # from whatever branch triggered the run. release/** branches carry stale
+      # landing sources (and lack newer header changes), so deploying their image
+      # would clobber the landings built from main. release/** still runs the build
+      # above, which pushes its versioned guide to gh-pages via mike; it just does
+      # not get promoted to prod. A subsequent main run (or manual workflow_dispatch)
+      # bakes the refreshed gh-pages versions into the prod image.
       - name: Trigger cloud deploy
         id: dispatch
+        if: github.ref_name == 'main'
         run: |
           echo "dispatched-at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
           gh api repos/VirtoCommerce/vc-github-actions/dispatches \
@@ -45,6 +58,7 @@ jobs:
           GH_TOKEN: ${{ secrets.REPO_TOKEN }}
 
       - name: Wait for cloud deploy
+        if: github.ref_name == 'main'
         timeout-minutes: 30
         run: |
           set -euo pipefail

--- a/overrides/assets/stylesheets/version-selector.css
+++ b/overrides/assets/stylesheets/version-selector.css
@@ -171,3 +171,18 @@ body:has(.md-search--active) .mega-menu {
     outline: 2px solid blue !important;
 }
 */
+
+
+/* ============================================
+   Preserve title casing in the version selector
+   ============================================ */
+
+/**
+ * .md-header__title applies text-transform: uppercase, which is inherited
+ * by the version selector text. Reset it on the selector's text elements so
+ * version titles render as authored ("Stable 14", not "STABLE 14").
+ */
+.md-version__current,
+.md-version__link {
+    text-transform: none;
+}


### PR DESCRIPTION
Resets `text-transform: none` on `.md-version__current`/`.md-version__link` so the dropdown reads `Stable 12` instead of `STABLE 12` on this version's pages. Sibling of #77 (main). ⚠️ Merging triggers a production docs deploy.