### PR TITLE
fix(build): content-hash extra_css to defeat Cloudflare CSS caching

### DIFF
--- a/marketplace/developer-guide/mkdocs.yml
+++ b/marketplace/developer-guide/mkdocs.yml
@@ -4,6 +4,7 @@ INHERIT: ../../mkdocs.yml
 hooks:
     - ../../overrides/hooks/abbreviations_loader.py
     - ../../overrides/hooks/search_index_fixer.py
+    - ../../overrides/hooks/extra_css_cache_bust.py
 
 # Override plugins for versioned site
 plugins:

--- a/marketplace/user-guide/mkdocs.yml
+++ b/marketplace/user-guide/mkdocs.yml
@@ -4,6 +4,7 @@ INHERIT: ../../mkdocs.yml
 hooks:
     - ../../overrides/hooks/abbreviations_loader.py
     - ../../overrides/hooks/search_index_fixer.py
+    - ../../overrides/hooks/extra_css_cache_bust.py
 
 # Override plugins for versioned site
 plugins:

--- a/overrides/hooks/extra_css_cache_bust.py
+++ b/overrides/hooks/extra_css_cache_bust.py
@@ -1,0 +1,51 @@
+"""Content-hash our own extra_css filenames so Cloudflare cannot serve a stale copy.
+
+Our extra_css entries (main.css, fonts.css, version-selector.css, ai-overrides.css)
+have stable, non-hashed URLs. Cloudflare caches them by URL, so editing a file does
+NOT change its URL and the edge keeps serving the pre-edit copy until the cache is
+purged. We have no Cloudflare access, so instead we rename each local extra_css file
+to include a short content hash at build time (e.g. version-selector.4f2a1c8e.css) and
+rewrite the <link> reference to match. Any future edit changes the hash, hence the URL,
+hence the cache key, so the edge always fetches the current file.
+
+Material already does this for its own bundled assets (main.<hash>.min.css); this hook
+extends the same cache-busting to our hand-written stylesheets.
+
+Registered per guide in mkdocs.yml under `hooks:`. External URLs (http(s)://, //) and
+files not found on disk are left untouched.
+"""
+
+import hashlib
+import os
+
+
+def on_files(files, config):
+    rewritten = []
+    for css in config.get("extra_css", []):
+        if "://" in css or css.startswith("//"):
+            rewritten.append(css)
+            continue
+
+        file = files.get_file_from_path(css)
+        abs_src = getattr(file, "abs_src_path", None) if file else None
+        if not abs_src or not os.path.isfile(abs_src):
+            # Not one of our local files (or already missing); leave as-is.
+            rewritten.append(css)
+            continue
+
+        with open(abs_src, "rb") as handle:
+            digest = hashlib.md5(handle.read()).hexdigest()[:8]
+
+        base, ext = os.path.splitext(css)
+        hashed = f"{base}.{digest}{ext}"
+
+        # Repoint the build output to the hashed name. dest_uri/url/abs_dest_path are
+        # cached_property values on mkdocs 1.6 File objects; assigning shadows them.
+        file.dest_uri = hashed
+        file.url = hashed
+        file.abs_dest_path = os.path.normpath(os.path.join(file.dest_dir, hashed))
+
+        rewritten.append(hashed)
+
+    config["extra_css"] = rewritten
+    return files

--- a/platform/deployment-on-cloud/mkdocs.yml
+++ b/platform/deployment-on-cloud/mkdocs.yml
@@ -4,6 +4,7 @@ INHERIT: ../../mkdocs.yml
 hooks:
     - ../../overrides/hooks/abbreviations_loader.py
     - ../../overrides/hooks/search_index_fixer.py
+    - ../../overrides/hooks/extra_css_cache_bust.py
 
 # Override plugins for versioned site
 plugins:

--- a/platform/developer-guide/mkdocs.yml
+++ b/platform/developer-guide/mkdocs.yml
@@ -4,6 +4,7 @@ INHERIT: ../../mkdocs.yml
 hooks:
     - ../../overrides/hooks/search_index_fixer.py
     - ../../overrides/hooks/abbreviations_loader.py
+    - ../../overrides/hooks/extra_css_cache_bust.py
 
 # Override plugins for versioned site
 # Note: INHERIT doesn't merge plugins, so we must include ALL needed plugins

--- a/platform/user-guide/mkdocs.yml
+++ b/platform/user-guide/mkdocs.yml
@@ -4,6 +4,7 @@ INHERIT: ../../mkdocs.yml
 hooks:
     - ../../overrides/hooks/search_index_fixer.py
     - ../../overrides/hooks/abbreviations_loader.py
+    - ../../overrides/hooks/extra_css_cache_bust.py
 
 # Override plugins for versioned site
 plugins:

--- a/storefront/developer-guide/mkdocs.yml
+++ b/storefront/developer-guide/mkdocs.yml
@@ -4,6 +4,7 @@ INHERIT: ../mkdocs.yml
 hooks:
     - ../../overrides/hooks/abbreviations_loader.py
     - ../../overrides/hooks/search_index_fixer.py
+    - ../../overrides/hooks/extra_css_cache_bust.py
 
 theme:
     custom_dir: ../../overrides

--- a/storefront/user-guide/mkdocs.yml
+++ b/storefront/user-guide/mkdocs.yml
@@ -4,6 +4,7 @@ INHERIT: ../../mkdocs.yml
 hooks:
     - ../../overrides/hooks/abbreviations_loader.py
     - ../../overrides/hooks/search_index_fixer.py
+    - ../../overrides/hooks/extra_css_cache_bust.py
 
 # Override plugins for versioned site
 plugins:


### PR DESCRIPTION
## Problem

Our `extra_css` files (`version-selector.css`, `ai-overrides.css`, `main.css`) have stable, non-hashed URLs. Cloudflare caches them by URL, so editing a file does **not** change its URL and the edge keeps serving the pre-edit copy.

Concretely: the version selector dropdown still rendered **UPPERCASE** on prod even after the #77 `text-transform: none` fix, because that fix lives in the already-cached `version-selector.css`. We have no Cloudflare access, so a purge is not an option.

## Fix

A mkdocs hook (`overrides/hooks/extra_css_cache_bust.py`) renames each local `extra_css` file to include a short content hash at build time (e.g. `version-selector.58e32d35.css`) and rewrites the `<link>`. Any future edit changes the hash → the URL → the cache key, so the edge always fetches the current file. This mirrors what Material already does for its own bundled assets (`main.<hash>.min.css`).

The #73 dedup step keeps per-version asset folders whose files are not a subset of root assets, so hashed names survive deduplication (no 404 on non-latest versions).

Registered in all seven versioned guide configs (where the version selector and its CSS appear).

## Verification

Built `platform/user-guide` and `storefront/user-guide` locally:
- `<link>` now points to `version-selector.<hash>.css` and `ai-overrides.<hash>.css`
- the hashed files exist in output and contain the casing fix
- builds pass