### PR TITLE
fix(build): content-hash extra_css to defeat Cloudflare CSS caching (release/1.0)

### DIFF
--- a/marketplace/developer-guide/mkdocs.yml
+++ b/marketplace/developer-guide/mkdocs.yml
@@ -3,6 +3,7 @@ INHERIT: ../../mkdocs.yml
 # Hooks to fix search index for versioned docs
 hooks:
     - ../../overrides/hooks/search_index_fixer.py
+    - ../../overrides/hooks/extra_css_cache_bust.py
 
 # Override plugins for versioned site
 plugins:

--- a/marketplace/user-guide/mkdocs.yml
+++ b/marketplace/user-guide/mkdocs.yml
@@ -3,6 +3,7 @@ INHERIT: ../../mkdocs.yml
 # Hooks to fix search index for versioned docs
 hooks:
     - ../../overrides/hooks/search_index_fixer.py
+    - ../../overrides/hooks/extra_css_cache_bust.py
 
 # Override plugins for versioned site
 plugins:

--- a/overrides/hooks/extra_css_cache_bust.py
+++ b/overrides/hooks/extra_css_cache_bust.py
@@ -1,18 +1,20 @@
-"""Content-hash our own extra_css filenames so Cloudflare cannot serve a stale copy.
+"""Append a content-hash query string to our extra_css links to defeat Cloudflare caching.
 
-Our extra_css entries (main.css, fonts.css, version-selector.css, ai-overrides.css)
-have stable, non-hashed URLs. Cloudflare caches them by URL, so editing a file does
-NOT change its URL and the edge keeps serving the pre-edit copy until the cache is
-purged. We have no Cloudflare access, so instead we rename each local extra_css file
-to include a short content hash at build time (e.g. version-selector.4f2a1c8e.css) and
-rewrite the <link> reference to match. Any future edit changes the hash, hence the URL,
-hence the cache key, so the edge always fetches the current file.
+Our extra_css entries (main.css, version-selector.css, ai-overrides.css) have stable,
+non-hashed URLs. Cloudflare caches them by URL, so editing a file does NOT change its
+URL and the edge keeps serving the pre-edit copy until purged. We have no Cloudflare
+access.
 
-Material already does this for its own bundled assets (main.<hash>.min.css); this hook
-extends the same cache-busting to our hand-written stylesheets.
+This hook appends a short content hash as a query string to each local extra_css link
+(e.g. version-selector.css?h=4f2a1c8e). Cloudflare's cache key includes the query
+string, so any edit changes the hash, hence the URL, hence the cache key, and the edge
+fetches the current file. The filename on disk is left unchanged, which keeps the
+versioned-build deduplication step working (it symlinks identical per-version asset
+folders to the root assets/; renaming files per build would defeat that and balloon the
+image past the runner's disk).
 
-Registered per guide in mkdocs.yml under `hooks:`. External URLs (http(s)://, //) and
-files not found on disk are left untouched.
+Registered per guide in mkdocs.yml under `hooks:`. External URLs and files not found on
+disk are left untouched.
 """
 
 import hashlib
@@ -22,30 +24,21 @@ import os
 def on_files(files, config):
     rewritten = []
     for css in config.get("extra_css", []):
-        if "://" in css or css.startswith("//"):
+        if "://" in css or css.startswith("//") or "?" in css:
             rewritten.append(css)
             continue
 
         file = files.get_file_from_path(css)
         abs_src = getattr(file, "abs_src_path", None) if file else None
         if not abs_src or not os.path.isfile(abs_src):
-            # Not one of our local files (or already missing); leave as-is.
+            # Not one of our local files; leave as-is.
             rewritten.append(css)
             continue
 
         with open(abs_src, "rb") as handle:
             digest = hashlib.md5(handle.read()).hexdigest()[:8]
 
-        base, ext = os.path.splitext(css)
-        hashed = f"{base}.{digest}{ext}"
-
-        # Repoint the build output to the hashed name. dest_uri/url/abs_dest_path are
-        # cached_property values on mkdocs 1.6 File objects; assigning shadows them.
-        file.dest_uri = hashed
-        file.url = hashed
-        file.abs_dest_path = os.path.normpath(os.path.join(file.dest_dir, hashed))
-
-        rewritten.append(hashed)
+        rewritten.append(f"{css}?h={digest}")
 
     config["extra_css"] = rewritten
     return files

--- a/overrides/hooks/extra_css_cache_bust.py
+++ b/overrides/hooks/extra_css_cache_bust.py
@@ -1,0 +1,51 @@
+"""Content-hash our own extra_css filenames so Cloudflare cannot serve a stale copy.
+
+Our extra_css entries (main.css, fonts.css, version-selector.css, ai-overrides.css)
+have stable, non-hashed URLs. Cloudflare caches them by URL, so editing a file does
+NOT change its URL and the edge keeps serving the pre-edit copy until the cache is
+purged. We have no Cloudflare access, so instead we rename each local extra_css file
+to include a short content hash at build time (e.g. version-selector.4f2a1c8e.css) and
+rewrite the <link> reference to match. Any future edit changes the hash, hence the URL,
+hence the cache key, so the edge always fetches the current file.
+
+Material already does this for its own bundled assets (main.<hash>.min.css); this hook
+extends the same cache-busting to our hand-written stylesheets.
+
+Registered per guide in mkdocs.yml under `hooks:`. External URLs (http(s)://, //) and
+files not found on disk are left untouched.
+"""
+
+import hashlib
+import os
+
+
+def on_files(files, config):
+    rewritten = []
+    for css in config.get("extra_css", []):
+        if "://" in css or css.startswith("//"):
+            rewritten.append(css)
+            continue
+
+        file = files.get_file_from_path(css)
+        abs_src = getattr(file, "abs_src_path", None) if file else None
+        if not abs_src or not os.path.isfile(abs_src):
+            # Not one of our local files (or already missing); leave as-is.
+            rewritten.append(css)
+            continue
+
+        with open(abs_src, "rb") as handle:
+            digest = hashlib.md5(handle.read()).hexdigest()[:8]
+
+        base, ext = os.path.splitext(css)
+        hashed = f"{base}.{digest}{ext}"
+
+        # Repoint the build output to the hashed name. dest_uri/url/abs_dest_path are
+        # cached_property values on mkdocs 1.6 File objects; assigning shadows them.
+        file.dest_uri = hashed
+        file.url = hashed
+        file.abs_dest_path = os.path.normpath(os.path.join(file.dest_dir, hashed))
+
+        rewritten.append(hashed)
+
+    config["extra_css"] = rewritten
+    return files

--- a/platform/deployment-on-cloud/mkdocs.yml
+++ b/platform/deployment-on-cloud/mkdocs.yml
@@ -3,6 +3,7 @@ INHERIT: ../../mkdocs.yml
 # Hooks to fix search index for versioned docs
 hooks:
     - ../../overrides/hooks/search_index_fixer.py
+    - ../../overrides/hooks/extra_css_cache_bust.py
 
 # Override plugins for versioned site
 plugins:

--- a/platform/developer-guide/mkdocs.yml
+++ b/platform/developer-guide/mkdocs.yml
@@ -3,6 +3,7 @@ INHERIT: ../../mkdocs.yml
 # Hooks to fix search index for versioned docs
 hooks:
     - ../../overrides/hooks/search_index_fixer.py
+    - ../../overrides/hooks/extra_css_cache_bust.py
 
 # Override plugins for versioned site
 # Note: INHERIT doesn't merge plugins, so we must include ALL needed plugins

--- a/platform/user-guide/mkdocs.yml
+++ b/platform/user-guide/mkdocs.yml
@@ -3,6 +3,7 @@ INHERIT: ../../mkdocs.yml
 # Hooks to fix search index for versioned docs
 hooks:
     - ../../overrides/hooks/search_index_fixer.py
+    - ../../overrides/hooks/extra_css_cache_bust.py
 
 # Override plugins for versioned site
 plugins:

--- a/storefront/developer-guide/mkdocs.yml
+++ b/storefront/developer-guide/mkdocs.yml
@@ -3,6 +3,7 @@ INHERIT: ../mkdocs.yml
 # Hooks to fix search index for versioned docs
 hooks:
     - ../../overrides/hooks/search_index_fixer.py
+    - ../../overrides/hooks/extra_css_cache_bust.py
 
 theme:
     custom_dir: ../../overrides

--- a/storefront/user-guide/mkdocs.yml
+++ b/storefront/user-guide/mkdocs.yml
@@ -3,6 +3,7 @@ INHERIT: ../../mkdocs.yml
 # Hooks to fix search index for versioned docs
 hooks:
     - ../../overrides/hooks/search_index_fixer.py
+    - ../../overrides/hooks/extra_css_cache_bust.py
 
 # Override plugins for versioned site
 plugins:


### PR DESCRIPTION
Backport of #82 to release/1.0. Adds the `extra_css_cache_bust.py` mkdocs hook and registers it in all seven versioned guide configs so stable10 pages serve a fresh, content-hashed `version-selector.css` (carrying the casing fix) instead of the Cloudflare-cached stale copy.

Verified: `platform/user-guide` builds on release/1.0 and emits `version-selector.<hash>.css`.