### PR TITLE
fix(build): cache-bust extra_css via query string (fixes disk-full deploy from #82)

### DIFF
--- a/overrides/hooks/extra_css_cache_bust.py
+++ b/overrides/hooks/extra_css_cache_bust.py
@@ -1,18 +1,20 @@
-"""Content-hash our own extra_css filenames so Cloudflare cannot serve a stale copy.
+"""Append a content-hash query string to our extra_css links to defeat Cloudflare caching.
 
-Our extra_css entries (main.css, fonts.css, version-selector.css, ai-overrides.css)
-have stable, non-hashed URLs. Cloudflare caches them by URL, so editing a file does
-NOT change its URL and the edge keeps serving the pre-edit copy until the cache is
-purged. We have no Cloudflare access, so instead we rename each local extra_css file
-to include a short content hash at build time (e.g. version-selector.4f2a1c8e.css) and
-rewrite the <link> reference to match. Any future edit changes the hash, hence the URL,
-hence the cache key, so the edge always fetches the current file.
+Our extra_css entries (main.css, version-selector.css, ai-overrides.css) have stable,
+non-hashed URLs. Cloudflare caches them by URL, so editing a file does NOT change its
+URL and the edge keeps serving the pre-edit copy until purged. We have no Cloudflare
+access.
 
-Material already does this for its own bundled assets (main.<hash>.min.css); this hook
-extends the same cache-busting to our hand-written stylesheets.
+This hook appends a short content hash as a query string to each local extra_css link
+(e.g. version-selector.css?h=4f2a1c8e). Cloudflare's cache key includes the query
+string, so any edit changes the hash, hence the URL, hence the cache key, and the edge
+fetches the current file. The filename on disk is left unchanged, which keeps the
+versioned-build deduplication step working (it symlinks identical per-version asset
+folders to the root assets/; renaming files per build would defeat that and balloon the
+image past the runner's disk).
 
-Registered per guide in mkdocs.yml under `hooks:`. External URLs (http(s)://, //) and
-files not found on disk are left untouched.
+Registered per guide in mkdocs.yml under `hooks:`. External URLs and files not found on
+disk are left untouched.
 """
 
 import hashlib
@@ -22,30 +24,21 @@ import os
 def on_files(files, config):
     rewritten = []
     for css in config.get("extra_css", []):
-        if "://" in css or css.startswith("//"):
+        if "://" in css or css.startswith("//") or "?" in css:
             rewritten.append(css)
             continue
 
         file = files.get_file_from_path(css)
         abs_src = getattr(file, "abs_src_path", None) if file else None
         if not abs_src or not os.path.isfile(abs_src):
-            # Not one of our local files (or already missing); leave as-is.
+            # Not one of our local files; leave as-is.
             rewritten.append(css)
             continue
 
         with open(abs_src, "rb") as handle:
             digest = hashlib.md5(handle.read()).hexdigest()[:8]
 
-        base, ext = os.path.splitext(css)
-        hashed = f"{base}.{digest}{ext}"
-
-        # Repoint the build output to the hashed name. dest_uri/url/abs_dest_path are
-        # cached_property values on mkdocs 1.6 File objects; assigning shadows them.
-        file.dest_uri = hashed
-        file.url = hashed
-        file.abs_dest_path = os.path.normpath(os.path.join(file.dest_dir, hashed))
-
-        rewritten.append(hashed)
+        rewritten.append(f"{css}?h={digest}")
 
     config["extra_css"] = rewritten
     return files


### PR DESCRIPTION
#82 renamed extra_css files to `version-selector.<hash>.css`, which made every version's asset folder differ from the root `assets/`. The #73 dedup then stopped symlinking those folders and the docker image ran out of disk (`no space left on device`), failing the main deploy.

This switches the hook to append a **content-hash query string** (`version-selector.css?h=<hash>`) instead of renaming the file:
- filename on disk is unchanged → dedup keeps working → image size unaffected
- the query string still changes the Cloudflare cache key on every CSS edit → the version-selector casing fix (and future CSS edits) reach prod

Verified locally: `platform/user-guide` build emits `...version-selector.css?h=58e32d35` and leaves the file unhashed on disk.