### PR TITLE
fix(header): version selector no longer overlaps the All topics mega-menu

### DIFF
--- a/overrides/assets/stylesheets/version-selector.css
+++ b/overrides/assets/stylesheets/version-selector.css
@@ -185,3 +185,32 @@ body:has(.md-search--active) .mega-menu {
 .md-version__link {
     text-transform: none;
 }
+
+/* ============================================
+   Prevent version selector / mega-menu overlap
+   ============================================ */
+
+/**
+ * Mike injects the version selector into .md-header__topic, which Material
+ * positions absolutely (for a page-title scroll animation that isn't used
+ * here: there is a single topic). Being absolute, the topic reserves no
+ * in-flow width, so the site title + version selector overflow their box and
+ * the "All topics" mega-menu (the next in-flow item) renders on top of them
+ * at every width from desktop down to tablet.
+ *
+ * Make the topic flow in-line so the logo reserves the real width of the
+ * title and version selector; the mega-menu then lays out after them.
+ */
+.md-header__topic {
+    position: static;
+}
+
+/* Keep the "All topics" button on one line and stop it from being squeezed
+   once the version selector takes its proper space. */
+.mega-menu {
+    flex: 0 0 auto;
+}
+
+.mega-menu__button {
+    white-space: nowrap;
+}


### PR DESCRIPTION
## Problem
The version selector (`Stable 14`) overlapped the `All topics` mega-menu button across all widths from desktop to tablet.

## Cause
Mike injects the version selector into Material's `.md-header__topic`, which is `position: absolute` (for a page-title scroll animation this site doesn't use — there's a single topic). Being absolute, the topic reserves no in-flow width, so the site title + version selector overflow their box and the mega-menu (next in-flow item) renders on top.

## Fix (CSS only, in version-selector.css)
- `.md-header__topic { position: static }` — topic flows in-line, logo reserves the real width of title + version
- `.mega-menu { flex: 0 0 auto }` + `.mega-menu__button { white-space: nowrap }` — keep "All topics" on one line once the version selector takes its space

## Verification
Measured + screenshotted live at 1280 / 1024 / 820 px: no overlap between version selector, mega-menu, or search; "All topics" stays on one line; below 768px both hide (existing behavior). Served fresh via the extra_css cache-bust hash.