### PR TITLE
fix(header): version selector no longer overlaps All topics mega-menu (release/1.0)

### DIFF
--- a/overrides/assets/stylesheets/version-selector.css
+++ b/overrides/assets/stylesheets/version-selector.css
@@ -186,3 +186,32 @@ body:has(.md-search--active) .mega-menu {
 .md-version__link {
     text-transform: none;
 }
+
+/* ============================================
+   Prevent version selector / mega-menu overlap
+   ============================================ */
+
+/**
+ * Mike injects the version selector into .md-header__topic, which Material
+ * positions absolutely (for a page-title scroll animation that isn't used
+ * here: there is a single topic). Being absolute, the topic reserves no
+ * in-flow width, so the site title + version selector overflow their box and
+ * the "All topics" mega-menu (the next in-flow item) renders on top of them
+ * at every width from desktop down to tablet.
+ *
+ * Make the topic flow in-line so the logo reserves the real width of the
+ * title and version selector; the mega-menu then lays out after them.
+ */
+.md-header__topic {
+    position: static;
+}
+
+/* Keep the "All topics" button on one line and stop it from being squeezed
+   once the version selector takes its proper space. */
+.mega-menu {
+    flex: 0 0 auto;
+}
+
+.mega-menu__button {
+    white-space: nowrap;
+}


### PR DESCRIPTION
Backport of #86 to release/1.0 (stable10). Makes Material's single `.md-header__topic` flow in-line so the version selector and `All topics` mega-menu no longer overlap. CSS-only, in version-selector.css.