### PR TITLE
Bump docs to stable15

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-stable14
+stable15


### PR DESCRIPTION
Release the next stable documentation version: `stable14` → `stable15`.

Per `VERSIONING.md`, this PR changes **only** the `VERSION` file so the bump-detection workflow recognizes it as a version bump.

## Merge instructions

- **Merge as a merge commit** (not squash, not rebase). The snapshot automation reads the previous version from `HEAD^1`, which only exists on a merge commit.
- On merge, automation will:
  - Create `release/stable14` from `HEAD^1` and push it.
  - Deploy `stable15` as `latest` and `default`.