### PR TITLE
Redirect legacy flat URLs and route 404s to docs root

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,14 @@ plugins:
     #       minify_html: true
     - redirects:
           redirect_maps:
+              # Legacy flat URLs (old /{section}-{guide}/ scheme still indexed by search engines).
+              # Each generates {key}/index.html served at /{key}/ that meta-refreshes to the current path.
+              "platform-user-guide.md": "https://docs.virtocommerce.org/platform/user-guide/latest/"
+              "platform-developer-guide.md": "https://docs.virtocommerce.org/platform/developer-guide/latest/"
+              "storefront-user-guide.md": "https://docs.virtocommerce.org/storefront/user-guide/latest/"
+              "storefront-developer-guide.md": "https://docs.virtocommerce.org/storefront/developer-guide/latest/"
+              "marketplace-user-guide.md": "https://docs.virtocommerce.org/marketplace/user-guide/latest/"
+              "marketplace-developer-guide.md": "https://docs.virtocommerce.org/marketplace/developer-guide/latest/"
               "products/products-virto3-versions.md": "https://docs.virtocommerce.org/platform/user-guide/latest/versions/virto3-products-versions"
               "license.md": "https://virtocommerce.com/open-source-license"
               "support.md": "https://help.virtocommerce.com/support/home"

--- a/overrides/404.html
+++ b/overrides/404.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{#
+  Catch-all 404: any not-found page redirects to the documentation root.
+  Targeted legacy URLs are handled earlier by the mkdocs-redirects plugin
+  (see redirect_maps in mkdocs.yml) and never reach this page.
+
+  NOTE: for this to fire on the live site, the serving layer (nginx in the
+  prod Docker image built by VirtoCommerce/vc-github-actions) must route
+  missing paths to /404.html, e.g. `error_page 404 /404.html;`.
+#}
+
+{% block extrahead %}
+  {{ super() }}
+  <meta http-equiv="refresh" content="0; url=/">
+  <script>
+    // Immediate client-side redirect; keeps the current query string dropped
+    // and always lands on the documentation home.
+    if (window.location.pathname !== "/") {
+      window.location.replace("/");
+    }
+  </script>
+{% endblock %}
+
+{% block content %}
+  <h1>Page not found</h1>
+  <p>The page you requested does not exist. Redirecting you to the
+     <a href="/">documentation home</a>.</p>
+{% endblock %}


### PR DESCRIPTION
Fixes broken search-engine-indexed links that point at the old flat URL scheme.

## Changes
- **mkdocs.yml** — add `redirect_maps` entries for legacy `/{section}-{guide}/` URLs (e.g. `/platform-user-guide/`). Each builds a stub page that meta-refreshes to the current `/{section}/{guide}/latest/` path.
- **overrides/404.html** — override the Material 404 page to redirect any other not-found path to the documentation root.

## Notes
- The root site (landings + redirects + 404) is baked into the prod image only from `main`, so this must deploy from `main`.
- The catch-all 404 to root behavior also requires the companion nginx change in `vc-github-actions` (separate PR) that routes not-found paths to `/404.html`.